### PR TITLE
#23 Make sure docker API listens on the private IP

### DIFF
--- a/ansible/playbooks/setup_environment.yml
+++ b/ansible/playbooks/setup_environment.yml
@@ -11,6 +11,7 @@
     - docker_engine
   vars:
     ansible_python_interpreter: "/usr/bin/python3" # (#19605)
+    ec2_metadata: "{{ hostvars['localhost']['ec2_metadata'] }}"
   tags: [setup_docker_host]
 
 - hosts: docker_hosts

--- a/ansible/roles/base/docker_engine/tasks/docker-service.yml
+++ b/ansible/roles/base/docker_engine/tasks/docker-service.yml
@@ -3,7 +3,7 @@
   lineinfile:
     path: "/lib/systemd/system/docker.service"
     regex: "^ExecStart=*"
-    line: "ExecStart=/usr/bin/dockerd -H fd:// -H tcp://0.0.0.0:2375"
+    line: "ExecStart=/usr/bin/dockerd -H fd:// -H tcp://{{ ec2_metadata.instances[0].private_ip_address }}:2375"
   notify: "Restart docker service and reload daemon"
 
 - name: "docker-service: Make sure docker-ce is setup"


### PR DESCRIPTION
It works. 
I love the message I got back from Docker: 
```
Feb 16 22:37:01 ip-172-31-6-118 dockerd[19794]: time="2019-02-16T22:37:01.944535157Z" level=warning msg="[!] DON'T BIND ON ANY IP ADDRESS WITHOUT setting --tlsverify IF YOU DON'T KNOW WHAT YOU'RE DOING [!]"
```