### PR TITLE
#48 Deploy node-emoji through new role in ansible

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -32,7 +32,7 @@ What you need is the following:
 
 - Create the environment. This will output the `private` and `public` `IPs` of the `EC2` instance. 
     ```
-    $ ansible-playbook -i inventories/dev/hosts.ini -l localhost playbooks/setup_environment.yml --skip-tags setup_docker_host
+    $ ansible-playbook -i inventories/dev/hosts.ini -l localhost playbooks/setup_environment.yml --skip-tags setup_docker_host,setup_node_app
     ```
 
 - Use the `public_IP` so you can connect to the host. I usually edit the `.ssh/config` file
@@ -43,29 +43,8 @@ What you need is the following:
     ```
 - Setup the host. 
     ```
-    ansible-playbook -i inventories/dev/hosts.ini -l localhost,docker_host playbooks/setup_environment.yml -e "jenkins_master_username=<username> jenkins_master_password=<password>"
+    ansible-playbook -i inventories/dev/hosts.ini -l localhost,docker_host playbooks/setup_environment.yml -e "jenkins_master_username=<username> jenkins_master_password=<password> emoji_build_version=<BUILD_VERSION>"
     ```
   Use the `-e "ansible_ssh_private_key_file=<your_pem_file>"` if you have one. 
 - It's now ready for you. Login to `jenkins-master` at `public_IP:8080` and use `username` and `password` you've set above. 
-- Setup a pipeline for building and testing the `nodejs` app like this 
-    ```
-    pipeline {
-     agent { label 'npm' }
-     stages {
-          stage('Checkout') {
-               steps {
-                    git url: 'https://github.com/ahfarmer/emoji-search.git'
-               }
-          }
-          stage('install') {
-               steps {
-                   sh 'npm install'
-               }
-          }
-          stage('test') {
-               steps {
-                   sh &'CI=true npm test'
-               }
-          }
-     }
-    ```
+- A pipeline for building and testing the `nodejs` app has already been setup.

--- a/ansible/inventories/dev/group_vars/all/main.yml
+++ b/ansible/inventories/dev/group_vars/all/main.yml
@@ -1,0 +1,5 @@
+---
+ansible_ssh_private_key_file: ""
+
+docker_registry_port: "5000"
+docker_registry_URI: "localhost:5000"

--- a/ansible/inventories/dev/group_vars/main.yml
+++ b/ansible/inventories/dev/group_vars/main.yml
@@ -1,2 +1,0 @@
----
-ansible_ssh_private_key_file: ""

--- a/ansible/playbooks/setup_environment.yml
+++ b/ansible/playbooks/setup_environment.yml
@@ -21,3 +21,9 @@
   vars:
     ec2_metadata: "{{ hostvars['localhost']['ec2_metadata'] }}"
   tags: [setup_docker_host]
+
+- hosts: docker_hosts
+  become: yes
+  roles:
+    - emoji_host
+  tags: [setup_node_app]

--- a/ansible/roles/services/docker_CICD/vars/main.yml
+++ b/ansible/roles/services/docker_CICD/vars/main.yml
@@ -19,9 +19,6 @@ docker_images:
     path: "/tmp/Dockerfiles/jenkins-master"
     dockerfile: "/tmp/Dockerfiles/jenkins-master/Dockerfile"
 
-docker_registry_port: "5000"
-docker_registry_URI: "localhost:5000"
-
 # These have to be set at execution. Next step would be to use ansible-vault (for starters)
 jenkins_master_username: ""
 jenkins_master_password: ""

--- a/ansible/roles/services/emoji_host/tasks/main.yml
+++ b/ansible/roles/services/emoji_host/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- name: "main: Deploy container"
+  include_tasks: "setup_container.yml"
+  

--- a/ansible/roles/services/emoji_host/tasks/setup_container.yml
+++ b/ansible/roles/services/emoji_host/tasks/setup_container.yml
@@ -1,0 +1,8 @@
+---
+- name: "setup_container: Create and start the emoji docker container"
+  docker_container:
+    name: "node-emoji"
+    image: "{{ docker_registry_URI }}/node-emoji:{{ emoji_build_version }}"
+    state: started
+    ports:
+      - "3000:3000"

--- a/ansible/roles/services/emoji_host/vars/main.yml
+++ b/ansible/roles/services/emoji_host/vars/main.yml
@@ -1,0 +1,2 @@
+---
+emoji_build_version: ""


### PR DESCRIPTION
This is checked as working: 
*Deploying the container*
```
$ ansible-playbook -i inventories/dev/hosts.ini -l docker_hosts  playbooks/setup_environment.yml -e "emoji_build_version=40" --tags setup_node_app 

PLAY [localhost] ****************************************************************************************************
skipping: no hosts matched

PLAY [docker_hosts] *************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************
ok: [cicd]

PLAY [docker_hosts] *************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************
ok: [cicd]

PLAY [docker_hosts] *************************************************************************************************

TASK [Gathering Facts] **********************************************************************************************
ok: [cicd]

TASK [emoji_host : main: Deploy container] **************************************************************************
included: /home/*******/CICD2/ansible/roles/services/emoji_host/tasks/setup_container.yml for cicd

TASK [emoji_host : setup_container: Create and start the emoji docker container] ************************************
changed: [cicd]

PLAY RECAP **********************************************************************************************************
cicd                       : ok=5    changed=1    unreachable=0    failed=0   
```
*Testing deployment*
```
$ curl http://xx.xx.xx.xx:3000/
<!doctype html>
<html lang="en">
  <head>
    <meta charset="utf-8">
    <meta name="viewport" content="width=device-wid
[...]
```